### PR TITLE
Change next_spawn to next_time

### DIFF
--- a/lessons/7-spawning.md
+++ b/lessons/7-spawning.md
@@ -27,7 +27,7 @@ So let's make a spawner!
 
         def prime(self):
             try:
-                self.next_spawn, self.next_position = next(self.generator)
+                self.next_time, self.next_position = next(self.generator)
             except StopIteration:
                 self.running = False
 


### PR DESCRIPTION
Fixes the following:

```
Traceback (most recent call last):
  File "main.py", line 120, in <module>
    main()
  File "main.py", line 117, in main
    engine.run()
  File "/usr/local/lib/python3.6/site-packages/ppb/engine.py", line 71, in run
    scene.simulate(self.delta_time)
  File "main.py", line 108, in simulate
    self.spawner.spawn(time_delta)
  File "main.py", line 28, in spawn
    while self.running and self.time >= self.next_time:
TypeError: '>=' not supported between instances of 'float' and 'NoneType'
```